### PR TITLE
WIP: Use grub2 in UEFI mode

### DIFF
--- a/templates/config_files/x86/grub2-efi.cfg
+++ b/templates/config_files/x86/grub2-efi.cfg
@@ -1,4 +1,4 @@
-set default="0"
+set default="1"
 
 function load_video {
   insmod efi_gop
@@ -15,25 +15,32 @@ insmod part_gpt
 insmod ext2
 insmod chain
 
-set timeout=5
+set timeout=60
 ### END /etc/grub.d/00_header ###
 
-# do not use search for ISO here, 'root' must point ESP, not the whole ISO9660
-# fs, otherwise xen.efi would not be able to access kernel and initrd
-
-menuentry 'Test media and install @PRODUCT@ @VERSION@' --class qubes --class gnu-linux --class gnu --class os {
-    chainloader @EFIDIR@/xen.efi placeholder qubes-check
-}
+search --no-floppy --set=root -l '@ISOLABEL@'
 
 menuentry 'Install @PRODUCT@ @VERSION@' --class qubes --class gnu-linux --class gnu --class os {
-    chainloader @EFIDIR@/xen.efi
+    multiboot2 @XENPATH@ console=none
+    module2 @KERNELPATH@ @ROOT@ quiet
+    module2 @INITRDPATH@
+}
+
+menuentry 'Test media and install @PRODUCT@ @VERSION@' --class qubes --class gnu-linux --class gnu --class os {
+    multiboot2 @XENPATH@ console=none
+    module2 @KERNELPATH@ @ROOT@ rd.live.check quiet
+    module2 @INITRDPATH@
 }
 
 menuentry 'Troubleshooting - verbose boot and Install @PRODUCT@ @VERSION@' --class qubes --class gnu-linux --class gnu --class os {
-    chainloader @EFIDIR@/xen.efi placeholder qubes-verbose
+    multiboot2 @XENPATH@ loglvl=all
+    module2 @KERNELPATH@ @ROOT@
+    module2 @INITRDPATH@
 }
 
 menuentry 'Rescue a @PRODUCT@ system' --class qubes --class gnu-linux --class gnu --class os {
-    chainloader @EFIDIR@/xen.efi placeholder qubes-rescue
+    multiboot2 @XENPATH@ console=none
+    module2 @KERNELPATH@ @ROOT@ rescue quiet
+    module2 @INITRDPATH@
 }
 

--- a/templates/config_files/x86/grub2-efi.cfg
+++ b/templates/config_files/x86/grub2-efi.cfg
@@ -22,13 +22,13 @@ search --no-floppy --set=root -l '@ISOLABEL@'
 
 menuentry 'Install @PRODUCT@ @VERSION@' --class qubes --class gnu-linux --class gnu --class os {
     multiboot2 @XENPATH@ console=none
-    module2 @KERNELPATH@ @ROOT@ quiet
+    module2 @KERNELPATH@ @ROOT@ plymouth.ignore-serial-consoles quiet
     module2 @INITRDPATH@
 }
 
 menuentry 'Test media and install @PRODUCT@ @VERSION@' --class qubes --class gnu-linux --class gnu --class os {
     multiboot2 @XENPATH@ console=none
-    module2 @KERNELPATH@ @ROOT@ rd.live.check quiet
+    module2 @KERNELPATH@ @ROOT@ plymouth.ignore-serial-consoles rd.live.check quiet
     module2 @INITRDPATH@
 }
 

--- a/templates/config_files/x86/isolinux.cfg
+++ b/templates/config_files/x86/isolinux.cfg
@@ -61,12 +61,12 @@ menu separator # insert an empty line
 label linux
   menu label ^Install @PRODUCT@ @VERSION@
   kernel mboot.c32
-  append xen.gz console=none --- vmlinuz @ROOT@ i915.alpha_support=1 quiet rhgb --- initrd.img
+  append xen.gz console=none --- vmlinuz @ROOT@ plymouth.ignore-serial-consoles i915.alpha_support=1 quiet rhgb --- initrd.img
 label check
   menu label Test this ^media & install @PRODUCT@ @VERSION@
   menu default
   kernel mboot.c32
-  append xen.gz console=none --- vmlinuz @ROOT@ i915.alpha_support=1 quiet rhgb rd.live.check --- initrd.img
+  append xen.gz console=none --- vmlinuz @ROOT@ plymouth.ignore-serial-consoles i915.alpha_support=1 quiet rhgb rd.live.check --- initrd.img
 
 menu separator # insert an empty line
 

--- a/templates/efi.tmpl
+++ b/templates/efi.tmpl
@@ -8,11 +8,33 @@ APPLE_EFI_DISKNAME=inroot+"/usr/share/pixmaps/bootloader/fedora-media.vol"
 
 mkdir ${EFIBOOTDIR}
 mkdir ${EFIBOOTDIR}/fonts/
-## Install xen.efi directly as BOOTX64.efi, reconsider grub when xen get multiboot2 support
-install boot/efi/EFI/*/xen*.efi ${EFIBOOTDIR}/BOOT${efiarch}.efi
+## Install grub only (no shim), as we don't have SecureBoot-signed xen/kernel
+## Create custom grub image, to include multiboot2 module
+<%
+grub_modules = "  all_video boot btrfs         \
+    cat configfile                  \
+    echo efifwsetup efinet ext2       \
+    fat font gfxmenu gfxterm gzio           \
+    halt hfsplus http increment iso9660 jpeg    \
+    loadenv loopback linux lvm lsefi lsefimmap	\
+    mdraid09 mdraid1x minicmd net           \
+    normal part_apple part_msdos part_gpt       \
+    password_pbkdf2 png reboot          \
+    search search_fs_uuid search_fs_file        \
+    search_label serial sleep syslinuxcfg test tftp \
+    video xfs \
+    backtrace chain usb usbserial_common usbserial_pl2303 usbserial_ftdi usbserial_usbdebug"
+grub_modules += " multiboot2"
+%>
+
+runcmd chroot ${inroot} mkdir -p /boot/efi/EFI/qubes
+runcmd chroot ${inroot} grub2-mkimage -O x86_64-efi \
+    -o /boot/efi/EFI/qubes/BOOT${efiarch}.EFI \
+    -p /EFI/BOOT ${grub_modules}
+install boot/efi/EFI/qubes/BOOT${efiarch}.EFI ${EFIBOOTDIR}/BOOT${efiarch}.EFI
 
 ## actually make the EFI images
-${make_efiboot("images/efiboot.img", include_kernel=True)}
+${make_efiboot("images/efiboot.img", include_kernel=False)}
 
 ## place fonts on ISO9660, but not in efiboot.img to save space
 install boot/efi/EFI/*/fonts/unicode.pf2 ${EFIBOOTDIR}/fonts/
@@ -21,7 +43,7 @@ install boot/efi/EFI/*/fonts/unicode.pf2 ${EFIBOOTDIR}/fonts/
 <%def name="make_efiboot(img, include_kernel=False, disk=False, imgtype='default')">
     <%
     kdir = EFIBOOTDIR if include_kernel else KERNELDIR
-    xenconf = "%s/BOOT%s.cfg" % (EFIBOOTDIR, efiarch)
+    eficonf = "%s/grub.cfg" % (EFIBOOTDIR, )
     args = "--label=ANACONDA --debug"
     scsi_modules   = " 3w-9xxx 3w-sas 3w-xxxx BusLogic a100u2w aacraid advansys aic79xx aic7xxx am53c974 arcmsr atp870u bfa bnx2fc csiostor dc395x dmx3191d esas2r esp_scsi fcoe fnic gdth hpsa hptiop hv_storvsc initio ipr ips isci iscsi_boot_sysfs libfc libfcoe libiscsi libosd libsas lpfc megaraid megaraid_mbox megaraid_mm megaraid_sas mpt2sas mpt3sas mvsas mvumi osd pm80xx pmcraid qla1280 qla2xxx qla4xxx raid_class scsi_debug scsi_dh_emc scsi_dh_rdac scsi_transport_fc scsi_transport_iscsi scsi_transport_sas scsi_transport_spi scsi_transport_srp stex sym53c8xx ufshcd virtio_scsi vmw_pvscsi wd719x"
     extra_modules  = " affs befs coda cuse dlm gfs2 mptfc ncpfs nilfs2 ocfs2 ocfs2_dlm ocfs2_dlmfs ocfs2_nodemanager ocfs2_stack_o2cb ocfs2_stack_user ocfs2_stackglue sctp sysv ubifs ufs"
@@ -49,12 +71,18 @@ install boot/efi/EFI/*/fonts/unicode.pf2 ${EFIBOOTDIR}/fonts/
         runcmd chroot ${inroot} rm -f /proc/modules
         install boot/efi/EFI/qubes/initrd-small.img ${EFIBOOTDIR}/initrd.img
     %endif
-    install ${configdir}/xen-efi.cfg ${xenconf}
-    replace @KERNELPATH@ /${kdir}/vmlinuz ${xenconf}
+    install ${configdir}/grub2-efi.cfg ${eficonf}
+    replace @PRODUCT@ '${product.name}' ${eficonf}
+    replace @VERSION@ ${product.version} ${eficonf}
+    replace @KERNELNAME@ vmlinuz ${eficonf}
+    replace @XENPATH@ /${kdir}/xen.gz ${eficonf}
+    replace @KERNELPATH@ /${kdir}/vmlinuz ${eficonf}
+    replace @INITRDPATH@ /${kdir}/initrd.img ${eficonf}
+    replace @ISOLABEL@ '${isolabel}' ${eficonf}
     %if disk:
-        replace @ROOT@ inst.stage2=hd:LABEL=ANACONDA ${xenconf}
+        replace @ROOT@ inst.stage2=hd:LABEL=ANACONDA ${eficonf}
     %else:
-        replace @ROOT@ 'inst.stage2=hd:LABEL=${isolabel|udev}' ${xenconf}
+        replace @ROOT@ 'inst.stage2=hd:LABEL=${isolabel|udev}' ${eficonf}
     %endif
     runcmd mkefiboot ${args} ${outroot}/${EFIBOOTDIR} ${outroot}/${img}
     # place those files to prevent Windows recreating them while writing ISO image

--- a/templates/runtime-install.tmpl
+++ b/templates/runtime-install.tmpl
@@ -38,8 +38,8 @@ installpkg glibc-all-langpacks
 %if basearch == "x86_64":
     installpkg grub2-tools-efi
     installpkg efibootmgr
-    installpkg shim-x64 grub2-efi-x64-cdboot
-    installpkg shim-ia32 grub2-efi-ia32-cdboot
+    installpkg shim-x64 grub2-efi-x64-cdboot grub2-efi-x64-modules
+    installpkg shim-ia32 grub2-efi-ia32-cdboot grub2-efi-ia32-modules
 %endif
 %if basearch in ("i386", "x86_64"):
     installpkg biosdevname memtest86+ syslinux

--- a/templates/x86.tmpl
+++ b/templates/x86.tmpl
@@ -28,7 +28,6 @@ install ${SYSLINUXDIR}/mboot.c32 ${BOOTDIR}
 install ${SYSLINUXDIR}/ldlinux.c32 ${BOOTDIR}
 install ${SYSLINUXDIR}/libcom32.c32 ${BOOTDIR}
 install ${SYSLINUXDIR}/libutil.c32 ${BOOTDIR}
-install boot/xen*gz ${BOOTDIR}/xen.gz
 install ${configdir}/isolinux.cfg ${BOOTDIR}
 install ${configdir}/boot.msg ${BOOTDIR}
 install ${configdir}/grub.conf ${BOOTDIR}
@@ -37,6 +36,7 @@ install boot/memtest* ${BOOTDIR}/memtest
 
 ## install kernels
 mkdir ${KERNELDIR}
+install boot/xen*gz ${KERNELDIR}/xen.gz
 <%
 sortedkernels = sorted(kernels, key=lambda k: LooseVersion(k['version']))
 latestkernel = sortedkernels[-1]
@@ -74,6 +74,7 @@ replace @PRODUCT@ '${product.name}'  ${BOOTDIR}/grub.conf ${BOOTDIR}/isolinux.cf
 replace @ROOT@ 'inst.stage2=hd:LABEL=${isolabel|udev}' ${BOOTDIR}/isolinux.cfg
 replace @EXTRAKERNELS@ '' ${BOOTDIR}/isolinux.cfg
 
+hardlink ${KERNELDIR}/xen.gz ${BOOTDIR}
 hardlink ${KERNELDIR}/vmlinuz ${BOOTDIR}
 hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
 %if basearch == 'x86_64':


### PR DESCRIPTION
Since Xen >= 4.11 supports multiboot2 on UEFI, grub can be used now.

Default Fedora grub-efi images do not have multiboot2 module includes,
so create image explicitly. Since condition on
boot/efi/EFI/*/gcdx64.efi existence doesn't make sense now, call efi
build unconditionally (keep %if and indentation for ease syncing with
upstream).

This is blocked for now, since grub2-efi-x64-modules in Fedora 29 doesn't
include multiboot2.mod (it was there in Fedora 28).

Fixes QubesOS/qubes-issues#4902