### PR TITLE
re-introduce support for multiple kernels

### DIFF
--- a/templates/config_files/x86/grub2-efi-entry.cfg
+++ b/templates/config_files/x86/grub2-efi-entry.cfg
@@ -1,0 +1,5 @@
+menuentry 'Install @PRODUCT@ @VERSION@ using @KVER@' --class qubes --class gnu-linux --class gnu --class os {
+    multiboot2 @XENPATH@ console=none
+    module2 @KERNELPATH@ @ROOT@ plymouth.ignore-serial-consoles quiet
+    module2 @INITRDPATH@
+}

--- a/templates/efi.tmpl
+++ b/templates/efi.tmpl
@@ -1,4 +1,4 @@
-<%page args="configdir, KERNELDIR, efiarch, isolabel, kver"/>
+<%page args="configdir, KERNELDIR, efiarch, isolabel, kver, shortkvers"/>
 <%
 EFIARCH_LOWER=efiarch.lower()
 EFIBOOTDIR="EFI/BOOT"
@@ -72,6 +72,14 @@ install boot/efi/EFI/*/fonts/unicode.pf2 ${EFIBOOTDIR}/fonts/
         install boot/efi/EFI/qubes/initrd-small.img ${EFIBOOTDIR}/initrd.img
     %endif
     install ${configdir}/grub2-efi.cfg ${eficonf}
+    %for shortkver in shortkvers[1:]:
+        install ${configdir}/grub2-efi-entry.cfg ${eficonf}-entry
+        replace @KVER@ ${shortkver} ${eficonf}-entry
+        replace @KERNELPATH@ /${kdir}/vmlinuz-${shortkver} ${eficonf}-entry
+        replace @INITRDPATH@ /${kdir}/initrd-${shortkver}.img ${eficonf}-entry
+        runcmd sh -c 'cat ${outroot}/${eficonf}-entry >> ${outroot}/${eficonf}'
+        remove ${eficonf}-entry
+    %endfor
     replace @PRODUCT@ '${product.name}' ${eficonf}
     replace @VERSION@ ${product.version} ${eficonf}
     replace @KERNELNAME@ vmlinuz ${eficonf}

--- a/templates/runtime-install.tmpl
+++ b/templates/runtime-install.tmpl
@@ -13,6 +13,7 @@ installpkg pigz
 
 ## kernel and firmware
 installpkg kernel
+installpkg kernel-latest
 installpkg grubby
 %if basearch != "s390x":
     installpkg linux-firmware

--- a/templates/x86.tmpl
+++ b/templates/x86.tmpl
@@ -39,14 +39,12 @@ mkdir ${KERNELDIR}
 install boot/xen*gz ${KERNELDIR}/xen.gz
 <%
 sortedkernels = sorted(kernels, key=lambda k: LooseVersion(k['version']))
+assert(len(sortedkernels) <= 2)
+# choose oldest - the LTS one
+defaultkernel = sortedkernels[0]
 latestkernel = sortedkernels[-1]
 shortkvers = []
 %>
-
-mkdir ${EXTRAKERNELS}
-# bypass "chroot" enforced by Lorax parser
--install ../../../../yum/dom0-updates/rpm/kernel-qubes-vm-[0-9]*rpm ${EXTRAKERNELS}
--remove ${EXTRAKERNELS}/kernel-qubes-vm-${latestkernel.version}.rpm
 
 %for kernel in sortedkernels:
     # Use short kernel version because of ISO9660 filename length limitation
@@ -54,19 +52,23 @@ mkdir ${EXTRAKERNELS}
     shortkver = kernel.version.replace('.pvops.qubes','').replace('.x86_64','')
     shortkvers.append(shortkver)
     %>
-    %if kernel.flavor:
-        ## i386 PAE
-        installkernel images-xen ${kernel.path} ${KERNELDIR}/vmlinuz-${kernel.flavor}
-        installinitrd images-xen ${kernel.initrd.path} ${KERNELDIR}/initrd-${kernel.flavor}.img
-    %else:
-        ## normal i386, x86_64
+    %if kernel == defaultkernel:
         installkernel images-${basearch} ${kernel.path} ${KERNELDIR}/vmlinuz
         installinitrd images-${basearch} ${kernel.initrd.path} ${KERNELDIR}/initrd.img
+    %else:
+        installkernel images-xen ${kernel.path} ${KERNELDIR}/vmlinuz-${shortkver}
+        installinitrd images-xen ${kernel.initrd.path} ${KERNELDIR}/initrd-${shortkver}.img
+        hardlink ${KERNELDIR}/vmlinuz-${shortkver} ${BOOTDIR}
+        hardlink ${KERNELDIR}/initrd-${shortkver}.img ${BOOTDIR}
+        hardlink ${KERNELDIR}/vmlinuz-${shortkver} ${KERNELDIR}/vmlinuz-latest
+        hardlink ${KERNELDIR}/initrd-${shortkver}.img ${BOOTDIR}/initrd-latest.img
+        replace '@EXTRAKERNELS@' 'label kernel-${kernel.version}\n\
+  menu indent count 5\n\
+  menu label ^Install @PRODUCT@ using ${kernel.version} kernel\n\
+  kernel mboot.c32\n\
+  append xen.gz --- vmlinuz-${shortkver} @ROOT@ quiet --- initrd-${shortkver}.img\n\
+@EXTRAKERNELS@' ${BOOTDIR}/isolinux.cfg
     %endif
-    installkernel images-alt-${shortkver} ${kernel.path} ${BOOTDIR}/vmlinuz-${shortkver}
-    installinitrd images-alt-${shortkver} ${kernel.initrd.path} ${BOOTDIR}/initrd-${shortkver}.img
-
-  <% latestkver = kernel.version %>
 
 %endfor
 
@@ -97,7 +99,7 @@ hardlink ${KERNELDIR}/initrd.img ${BOOTDIR}
         efigraft += " {0}={1}/{0}".format(img,outroot)
     efihybrid = "--uefi"
     %>
-    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch=efiarch, isolabel=isolabel, kver=latestkver"/>
+    <%include file="efi.tmpl" args="configdir=configdir, KERNELDIR=KERNELDIR, efiarch=efiarch, isolabel=isolabel, kver=defaultkernel.version, shortkvers=shortkvers"/>
 %endif
 
 # Support for productmd format


### PR DESCRIPTION
This more or less reverts 969e2df9145edd0d392767beb80b85eed033b295
(while it was still in the installer-qubes-os repo).

The previous implementation did not supported EFI boot, so add it here
this time.
While at it, drop unused kernel "flavors" support and do not install
kernel binaries multiple times.

Adds also a hardlink for latest kernel (in addition to the default one).
This mostly eases automatic processing (OEM images, tests, network boot etc).

Fixes https://github.com/QubesOS/qubes-issues/issues/5900