### PR TITLE
Add hidden "OEM installation" option

### DIFF
--- a/templates/config_files/x86/grub2-bios.cfg
+++ b/templates/config_files/x86/grub2-bios.cfg
@@ -43,3 +43,12 @@ menuentry 'Rescue a @PRODUCT@ system' --class qubes --class gnu-linux --class gn
     module2 @KERNELPATH@ @ROOT@ inst.rescue quiet
     module2 @INITRDPATH@
 }
+
+if search --set=oem -l QUBES_OEM; then
+    menuentry 'OEM installation (with kickstart file)' --id qubes-oem {
+        multiboot2 @XENPATH@ console=none
+        module2 @KERNELPATH@ @ROOT@ plymouth.ignore-serial-consoles quiet inst.ks=hd:LABEL=QUBES_OEM
+        module2 @INITRDPATH@
+    }
+    set default="qubes-oem"
+fi

--- a/templates/config_files/x86/grub2-efi.cfg
+++ b/templates/config_files/x86/grub2-efi.cfg
@@ -43,3 +43,12 @@ menuentry 'Rescue a @PRODUCT@ system' --class qubes --class gnu-linux --class gn
     module2 @KERNELPATH@ @ROOT@ inst.rescue quiet
     module2 @INITRDPATH@
 }
+
+if search --set=oem -l QUBES_OEM; then
+    menuentry 'OEM installation (with kickstart file)' --id qubes-oem {
+        multiboot2 @XENPATH@ console=none
+        module2 @KERNELPATH@ @ROOT@ plymouth.ignore-serial-consoles quiet inst.ks=hd:LABEL=QUBES_OEM
+        module2 @INITRDPATH@
+    }
+    set default="qubes-oem"
+fi


### PR DESCRIPTION
This allows using unmodified installation image to perform automated
install. Previously, it required either adding boot option manually, or
building own installation disk with boot configs adjusted.

How to use:
 - create USB stick with a partition labeled "QUBES_OEM" (important!)
 - put "ks.cfg" file in the root directory, possibly with other files it
   needs
 - plug both original Qubes OS installation image and the QUBES_OEM
   stick to the computer
 - boot Qubes OS installation

It should automatically detect QUBES_OEM stick, and select it as default
boot option (menu is still showed up, so user can still select manual
installation).

The "OEM installation" option is visible (and selected) only when
QUBES_OEM usb stick is plugged. Otherwise it's hidden.