### PR TITLE
grub: always load both part_gpt and part_msdos

### DIFF
--- a/templates/config_files/x86/grub2-bios.cfg
+++ b/templates/config_files/x86/grub2-bios.cfg
@@ -12,6 +12,7 @@ load_video
 set gfxpayload=keep
 insmod gzio
 insmod part_gpt
+insmod part_msdos
 insmod ext2
 insmod chain
 

--- a/templates/config_files/x86/grub2-efi.cfg
+++ b/templates/config_files/x86/grub2-efi.cfg
@@ -12,6 +12,7 @@ load_video
 set gfxpayload=keep
 insmod gzio
 insmod part_gpt
+insmod part_msdos
 insmod ext2
 insmod chain
 


### PR DESCRIPTION
Regardless of the boot mode, load both. This helps with handling
slightly customized install images - like an alternative partition
layout (see QubesOS/qubes-issues#8732), or OEM config stick.